### PR TITLE
libs/driver.js::loadSync

### DIFF
--- a/libs/driver.js
+++ b/libs/driver.js
@@ -19,7 +19,7 @@ function loadSync(fileName) {
                     end: parseInt(trim(p[3])),
                     value: {
                         code: trim(p[4]),
-                        country: trim(p[5])
+                        country: trim(p.slice(5).join(','))
                     }
                 }
             }


### PR DESCRIPTION
If there's a comma(,) in country name, loadSync function returns only partial name.
"Korea, Republic of", for example, has comma in it, and p[5] is only "Korea". (after calling trim function with it, it becomes "Kore")
Fix that.